### PR TITLE
Fix text-ui-test

### DIFF
--- a/src/main/java/seedu/trippie/Storage.java
+++ b/src/main/java/seedu/trippie/Storage.java
@@ -55,7 +55,7 @@ public class Storage {
 
             if (file.createNewFile()) {
                 System.out.println("I can't find a file in your directory :(");
-                System.out.println("I created a new " + file.getPath() + " file for you!");
+                System.out.println("I created a new " + file.getName() + " file for you!");
 
             } else if (!file.createNewFile()) {
                 System.out.println("I found a file in your directory!\nSetting up the file now...");

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -9,7 +9,7 @@ Welcome to
 							Travel made easy
 _________________________________________________________________________
 I can't find a file in your directory :(
-I created a new trippie_data/trippie.txt file for you!
+I created a new trippie.txt file for you!
 Please create a new trip by entering 'new trip'
 >> _________________________________________________________________________
 Invalid Command! Type "help" to view the commands available!


### PR DESCRIPTION
Solve the Gradle check issue.

Cause of error:
Windows and UNIX file path is different `trippie_data\trippie.txt` vs `trippie_data/trippie.txt` and we followed the UNIX file path. Hence, it always fail on Windows Test.

Solution:
Print file name instead of file path `trippie.txt`